### PR TITLE
Update code to the latest JDA versions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/README.md
+++ b/README.md
@@ -45,3 +45,14 @@ DiscordHtmlTranscripts transcript = DiscordHtmlTranscripts.getInstance();
 transcript.generateFromMessages(messages); // return to InputStream
 ```
 
+### You can also put the transcript into a variable
+```java
+DiscordHtmlTranscripts transcripts = new DiscordHtmlTranscripts();
+try {
+	testChannel.sendFiles(transcripts.getTranscript(testChannel, "test.html")).queue();
+} catch (IOException e) {
+	throw new RuntimeException(e);
+}
+```
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,22 +6,52 @@
 
     <groupId>me.ryzeon.html</groupId>
     <artifactId>discord-html-transcripts</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>17</source>
+                    <target>17</target>
+                    <compilerArgs>
+                        <arg>--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                        <arg>--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                        <arg>--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                        <arg>--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                        <arg>--add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                        <arg>--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                    </compilerArgs>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>me.ryzeon.html.DiscordHtmlTranscripts</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -38,21 +68,21 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.3.0_322</version>
+            <version>5.0.0-Beta.20</version>
         </dependency>
 
         <dependency>
             <!-- jsoup HTML parser library @ https://jsoup.org/ -->
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.14.3</version>
+            <version>1.15.3</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/me/ryzeon/transcripts/DiscordHtmlTranscripts.java
+++ b/src/main/java/me/ryzeon/transcripts/DiscordHtmlTranscripts.java
@@ -1,14 +1,21 @@
 package me.ryzeon.transcripts;
 
-import lombok.var;
+import lombok.Getter;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.utils.FileUpload;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 import java.awt.*;
-import java.io.*;
-import java.net.URL;;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.List;
@@ -16,6 +23,7 @@ import java.util.stream.Collectors;
 
 /**
  * Created by Ryzeon
+ * Edited by Incbom
  * Project: discord-html-transcripts
  * Date: 2/12/21 @ 00:32
  * Twitter: @Ryzeon_ 😎
@@ -29,39 +37,67 @@ public class DiscordHtmlTranscripts {
             audioFormats = Arrays.asList("mp3", "wav", "ogg", "flac");
 
 
+    @Getter
     private static final DiscordHtmlTranscripts instance = new DiscordHtmlTranscripts();
 
-    public static DiscordHtmlTranscripts getInstance() {
-        return instance;
-    }
-
+    /**
+     * This method sends the transcript in the channel it is logging. To get the FileUpload object, use {@link #getTranscript(TextChannel, String)}. To get the InputStream object, use {@link #generateFromMessages(Collection)}.
+     * @param channel Channel to generate transcript from
+     */
     public void createTranscript(TextChannel channel) throws IOException {
-        createTranscript(channel, null);
+        createTranscript(channel, "transcript.html");
     }
 
-    public void createTranscript(TextChannel channel, String fileName) throws IOException {
-        channel.sendFile(generateFromMessages(channel.getIterableHistory().stream().collect(Collectors.toList())), fileName != null ? fileName : "transcript.html").queue();
+    /**
+     * This method sends the transcript in the channel it is logging. To get the InputStream object, use {@link #generateFromMessages(Collection)}.
+     * @param channel Channel to generate transcript from
+     * @param fileName Name of the file
+     * @return Returns a usable FileUpload object to send to a channel
+     */
+    public FileUpload getTranscript(TextChannel channel, String fileName) throws IOException {
+        return FileUpload.fromData(convertInputStreamToFile(generateFromMessages(channel.getIterableHistory().stream().collect(Collectors.toList())), fileName));
     }
 
-    public InputStream generateFromMessages(Collection<Message> messages) throws IOException {
-        File htmlTemplate = findFile("template.html");
+    private void createTranscript(TextChannel channel, String fileName) throws IOException {
+        FileUpload transcript = FileUpload.fromData(convertInputStreamToFile(generateFromMessages(channel.getIterableHistory().stream().collect(Collectors.toList())), fileName != null ? fileName : "transcript.html"));
+        channel.sendFiles(transcript).queue();;
+    }
+
+    private File convertInputStreamToFile(InputStream is, String fileName) throws IOException {
+        File file = new File(fileName);
+        Files.copy(is, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return file;
+    }
+
+    private InputStream generateFromMessages(Collection<Message> messages) throws IOException {
+        InputStream htmlTemplate = findFile();
         if (messages.isEmpty()) {
             throw new IllegalArgumentException("No messages to generate a transcript from");
         }
-        TextChannel channel = messages.iterator().next().getTextChannel();
-        Document document = Jsoup.parse(htmlTemplate, "UTF-8");
+        TextChannel channel = messages.iterator().next().getJDA().getTextChannelById(messages.iterator().next().getChannel().getId());
+        Document document = Jsoup.parse(htmlTemplate, "UTF-8", "");
         document.outputSettings().indentAmount(0).prettyPrint(true);
-        document.getElementsByClass("preamble__guild-icon")
-                .first().attr("src", channel.getGuild().getIconUrl()); // set guild icon
+        assert channel != null;
+        Element preambleGuildIcon = document.getElementsByClass("preamble__guild-icon").first();
+        String guildIconUrl = channel.getGuild().getIconUrl();
 
-        document.getElementById("transcriptTitle").text(channel.getName()); // set title
-        document.getElementById("guildname").text(channel.getGuild().getName()); // set guild name
-        document.getElementById("ticketname").text(channel.getName()); // set channel name
+        if (preambleGuildIcon != null && guildIconUrl != null) {
+            preambleGuildIcon.attr("src", guildIconUrl);
+        } else {
+            preambleGuildIcon.attr("src", "https://guild-studio.com/wp-content/uploads/2021/05/s9biyhs4lix61.jpg");
+        }
+        Objects.requireNonNull(document.getElementById("transcriptTitle")).text(channel.getName()); // set title
+        Objects.requireNonNull(document.getElementById("guildname")).text(channel.getGuild().getName()); // set guild name
+        Objects.requireNonNull(document.getElementById("ticketname")).text(channel.getName()); // set channel name
 
         Element chatLog = document.getElementById("chatlog"); // chat log
         for (Message message : messages.stream()
                 .sorted(Comparator.comparing(ISnowflake::getTimeCreated))
-                .collect(Collectors.toList())) {
+                .toList()) {
+
+            if (message.getAuthor().isBot()) {
+                continue;
+            }
             // create message group
             Element messageGroup = document.createElement("div");
             messageGroup.addClass("chatlog__message-group");
@@ -79,27 +115,17 @@ public class DiscordHtmlTranscripts {
 
                 var referenceMessage = message.getReferencedMessage();
                 User author = referenceMessage.getAuthor();
-                Member member = channel.getGuild().getMember(author);
-                var color = Formatter.toHex(Objects.requireNonNull(member.getColor()));
 
                 //        System.out.println("REFERENCE MSG " + referenceMessage.getContentDisplay());
-                reference.html("<img class=\"chatlog__reference-avatar\" src=\""
-                        + author.getAvatarUrl() + "\" alt=\"Avatar\" loading=\"lazy\">" +
-                        "<span class=\"chatlog__reference-name\" title=\"" + author.getName()
-                        + "\" style=\"color: " + color + "\">" + author.getName() + "\"</span>" +
-                        "<div class=\"chatlog__reference-content\">" +
-                        " <span class=\"chatlog__reference-link\" onclick=\"scrollToMessage(event, '"
-                        + referenceMessage.getId() + "')\">" +
-                        "<em>" +
-                        referenceMessage.getContentDisplay() != null
-                        ? referenceMessage.getContentDisplay().length() > 42
-                        ? referenceMessage.getContentDisplay().substring(0, 42)
-                        + "..."
-                        : referenceMessage.getContentDisplay()
-                        : "Click to see attachment" +
-                        "</em>" +
-                        "</span>" +
-                        "</div>");
+                author.getAvatarUrl();
+                author.getName();
+                author.getName();
+                referenceMessage.getId();
+                referenceMessage.getContentDisplay();
+                reference.html(referenceMessage.getContentDisplay().length() > 42
+                ? referenceMessage.getContentDisplay().substring(0, 42)
+                + "..."
+                : referenceMessage.getContentDisplay());
 
                 messageGroup.appendChild(referenceSymbol);
                 messageGroup.appendChild(reference);
@@ -112,9 +138,24 @@ public class DiscordHtmlTranscripts {
 
             Element authorAvatar = document.createElement("img");
             authorAvatar.addClass("chatlog__author-avatar");
-            authorAvatar.attr("src", author.getAvatarUrl());
             authorAvatar.attr("alt", "Avatar");
             authorAvatar.attr("loading", "lazy");
+
+            Element authorName = document.createElement("span");
+            authorName.addClass("chatlog__author-name");
+
+            if (author != null) {
+                authorName.attr("title", Objects.requireNonNull(author.getGlobalName()));
+                authorName.text(author.getName());
+                authorName.attr("data-user-id", author.getId());
+                authorAvatar.attr("src", Objects.requireNonNull(author.getAvatarUrl()));
+            } else {
+                // Handle the case when author is null (e.g., when the message is from a bot)
+                authorName.attr("title", "Bot");
+                authorName.text("Bot");
+                authorName.attr("data-user-id", "Bot");
+                authorAvatar.attr("src", "default_bot_avatar_url"); // replace with your default bot avatar URL
+            }
 
             authorElement.appendChild(authorAvatar);
             messageGroup.appendChild(authorElement);
@@ -122,16 +163,10 @@ public class DiscordHtmlTranscripts {
             // message content
             Element content = document.createElement("div");
             content.addClass("chatlog__messages");
-            // message author name
-            Element authorName = document.createElement("span");
-            authorName.addClass("chatlog__author-name");
-            // authorName.attr("title", author.getName()); // author.name
-            authorName.attr("title", author.getAsTag());
-            authorName.text(author.getName());
-            authorName.attr("data-user-id", author.getId());
+
             content.appendChild(authorName);
 
-            if (author.isBot()) {
+            if (author != null && author.isBot()) {
                 Element botTag = document.createElement("span");
                 botTag.addClass("chatlog__bot-tag").text("BOT");
                 content.appendChild(botTag);
@@ -152,7 +187,7 @@ public class DiscordHtmlTranscripts {
             messageContent.attr("title", "Message sent: "
                     + message.getTimeCreated().format(DateTimeFormatter.ofPattern("HH:mm:ss")));
 
-            if (message.getContentDisplay().length() > 0) {
+            if (!message.getContentDisplay().isEmpty()) {
                 Element messageContentContent = document.createElement("div");
                 messageContentContent.addClass("chatlog__content");
 
@@ -161,13 +196,6 @@ public class DiscordHtmlTranscripts {
 
                 Element messageContentContentMarkdownSpan = document.createElement("span");
                 messageContentContentMarkdownSpan.addClass("preserve-whitespace");
-//                System.out.println(message.getContentDisplay());
-//                System.out.println(message.getContentDisplay().length());
-//                System.out.println(message.getContentStripped());
-//                System.out.println(message.getContentRaw());
-//                System.out.println(message.getContentDisplay().contains("\n"));
-//                System.out.println(message.getContentDisplay().contains("\r"));
-//                System.out.println(message.getContentDisplay().contains("\r\n"));
                 messageContentContentMarkdownSpan
                         .html(Formatter.format(message.getContentDisplay()));
 
@@ -371,7 +399,7 @@ public class DiscordHtmlTranscripts {
 
                             Element embedFieldNameMarkdown = document.createElement("div");
                             embedFieldNameMarkdown.addClass("markdown preserve-whitespace");
-                            embedFieldNameMarkdown.html(field.getName());
+                            embedFieldNameMarkdown.html(Objects.requireNonNull(field.getName()));
 
                             embedFieldName.appendChild(embedFieldNameMarkdown);
                             embedField.appendChild(embedFieldName);
@@ -404,7 +432,7 @@ public class DiscordHtmlTranscripts {
 
                         Element embedThumbnailLink = document.createElement("a");
                         embedThumbnailLink.addClass("chatlog__embed-thumbnail-link");
-                        embedThumbnailLink.attr("href", embed.getThumbnail().getUrl());
+                        embedThumbnailLink.attr("href", Objects.requireNonNull(embed.getThumbnail().getUrl()));
 
                         Element embedThumbnailImage = document.createElement("img");
                         embedThumbnailImage.addClass("chatlog__embed-thumbnail");
@@ -461,7 +489,7 @@ public class DiscordHtmlTranscripts {
                         embedFooterText.text(embed.getTimestamp() != null
                                 ? embed.getFooter().getText() + " • " + embed.getTimestamp()
                                 .format(DateTimeFormatter.ofPattern("HH:mm:ss"))
-                                : embed.getFooter().getText());
+                                : Objects.requireNonNull(embed.getFooter().getText()));
 
                         embedFooter.appendChild(embedFooterText);
 
@@ -474,16 +502,17 @@ public class DiscordHtmlTranscripts {
             }
 
             messageGroup.appendChild(content);
+            assert chatLog != null;
             chatLog.appendChild(messageGroup);
         }
         return new ByteArrayInputStream(document.outerHtml().getBytes());
     }
 
-    private File findFile(String fileName) {
-        URL url = getClass().getClassLoader().getResource(fileName);
-        if (url == null) {
-            throw new IllegalArgumentException("file is not found: " + fileName);
+    private InputStream findFile() {
+        InputStream is = getClass().getClassLoader().getResourceAsStream("template.html");
+        if (is == null) {
+            throw new IllegalArgumentException("file is not found: " + "template.html");
         }
-        return new File(url.getFile());
+        return is;
     }
 }

--- a/src/main/java/me/ryzeon/transcripts/DiscordHtmlTranscripts.java
+++ b/src/main/java/me/ryzeon/transcripts/DiscordHtmlTranscripts.java
@@ -1,7 +1,10 @@
 package me.ryzeon.transcripts;
 
 import lombok.Getter;
-import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.ISnowflake;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.utils.FileUpload;
 import org.jsoup.Jsoup;
@@ -16,7 +19,6 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -53,11 +55,11 @@ public class DiscordHtmlTranscripts {
      * @return Returns a usable FileUpload object to send to a channel
      */
     public FileUpload getTranscript(TextChannel channel, String fileName) throws IOException {
-        return FileUpload.fromData(generateFromMessages(channel.getIterableHistory().stream().collect(Collectors.toList())), fileName);
+        return FileUpload.fromData((generateFromMessages(channel.getIterableHistory().stream().collect(Collectors.toList()))), fileName);
     }
 
     private void createTranscript(TextChannel channel, String fileName) throws IOException {
-        FileUpload transcript = FileUpload.fromData(generateFromMessages(channel.getIterableHistory().stream().collect(Collectors.toList())), fileName != null ? fileName : "transcript.html");
+        FileUpload transcript = FileUpload.fromData((generateFromMessages(channel.getIterableHistory().stream().collect(Collectors.toList()))), fileName != null ? fileName : "transcript.html");
         channel.sendFiles(transcript).queue();;
     }
 
@@ -76,7 +78,7 @@ public class DiscordHtmlTranscripts {
         if (preambleGuildIcon != null && guildIconUrl != null) {
             preambleGuildIcon.attr("src", guildIconUrl);
         } else {
-            // Handle the case where either the element or the URL is null
+            preambleGuildIcon.attr("src", "https://guild-studio.com/wp-content/uploads/2021/05/s9biyhs4lix61.jpg");
         }
         Objects.requireNonNull(document.getElementById("transcriptTitle")).text(channel.getName()); // set title
         Objects.requireNonNull(document.getElementById("guildname")).text(channel.getGuild().getName()); // set guild name
@@ -86,6 +88,10 @@ public class DiscordHtmlTranscripts {
         for (Message message : messages.stream()
                 .sorted(Comparator.comparing(ISnowflake::getTimeCreated))
                 .toList()) {
+
+            if (message.getAuthor().isBot()) {
+                continue;
+            }
             // create message group
             Element messageGroup = document.createElement("div");
             messageGroup.addClass("chatlog__message-group");
@@ -111,9 +117,9 @@ public class DiscordHtmlTranscripts {
                 referenceMessage.getId();
                 referenceMessage.getContentDisplay();
                 reference.html(referenceMessage.getContentDisplay().length() > 42
-                ? referenceMessage.getContentDisplay().substring(0, 42)
-                + "..."
-                : referenceMessage.getContentDisplay());
+                        ? referenceMessage.getContentDisplay().substring(0, 42)
+                        + "..."
+                        : referenceMessage.getContentDisplay());
 
                 messageGroup.appendChild(referenceSymbol);
                 messageGroup.appendChild(reference);
@@ -126,9 +132,24 @@ public class DiscordHtmlTranscripts {
 
             Element authorAvatar = document.createElement("img");
             authorAvatar.addClass("chatlog__author-avatar");
-            authorAvatar.attr("src", Objects.requireNonNull(author.getAvatarUrl()));
             authorAvatar.attr("alt", "Avatar");
             authorAvatar.attr("loading", "lazy");
+
+            Element authorName = document.createElement("span");
+            authorName.addClass("chatlog__author-name");
+
+            if (author != null) {
+                authorName.attr("title", Objects.requireNonNull(author.getGlobalName()));
+                authorName.text(author.getName());
+                authorName.attr("data-user-id", author.getId());
+                authorAvatar.attr("src", Objects.requireNonNull(author.getAvatarUrl()));
+            } else {
+                // Handle the case when author is null (e.g., when the message is from a bot)
+                authorName.attr("title", "Bot");
+                authorName.text("Bot");
+                authorName.attr("data-user-id", "Bot");
+                authorAvatar.attr("src", "default_bot_avatar_url"); // replace with your default bot avatar URL
+            }
 
             authorElement.appendChild(authorAvatar);
             messageGroup.appendChild(authorElement);
@@ -136,15 +157,10 @@ public class DiscordHtmlTranscripts {
             // message content
             Element content = document.createElement("div");
             content.addClass("chatlog__messages");
-            // message author name
-            Element authorName = document.createElement("span");
-            authorName.addClass("chatlog__author-name");
-            authorName.attr("title", Objects.requireNonNull(author.getGlobalName()));
-            authorName.text(author.getName());
-            authorName.attr("data-user-id", author.getId());
+
             content.appendChild(authorName);
 
-            if (author.isBot()) {
+            if (author != null && author.isBot()) {
                 Element botTag = document.createElement("span");
                 botTag.addClass("chatlog__bot-tag").text("BOT");
                 content.appendChild(botTag);
@@ -371,7 +387,7 @@ public class DiscordHtmlTranscripts {
                             embedField.addClass(field.isInline() ? "chatlog__embed-field-inline"
                                     : "chatlog__embed-field");
 
-                            // Field nmae
+                            // Field name
                             Element embedFieldName = document.createElement("div");
                             embedFieldName.addClass("chatlog__embed-field-name");
 

--- a/src/main/java/me/ryzeon/transcripts/DiscordHtmlTranscripts.java
+++ b/src/main/java/me/ryzeon/transcripts/DiscordHtmlTranscripts.java
@@ -1,24 +1,24 @@
 package me.ryzeon.transcripts;
 
 import lombok.Getter;
-import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.ISnowflake;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.utils.FileUpload;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
-import java.awt.*;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -393,7 +393,7 @@ public class DiscordHtmlTranscripts {
                             embedField.addClass(field.isInline() ? "chatlog__embed-field-inline"
                                     : "chatlog__embed-field");
 
-                            // Field nmae
+                            // Field name
                             Element embedFieldName = document.createElement("div");
                             embedFieldName.addClass("chatlog__embed-field-name");
 


### PR DESCRIPTION
# Purpose of the PR
This pull request is meant to make this library usable on the latest version of JDA (v5.0.0-beta.20) and translate old code to new code. The PR also adds null checks and removes bots from the transcript as they cause issues.

## Changes
As highlighted above, the PR converts TextChannel and the file-sending methods to newer technology. The method of getting the template.html has changed as well. 

## Why is this necessary 
This upgrade makes this library usable by modern discord bots. 

## Additions
There is also a new method to return a FileUpload object to hold the transcript as a variable for later use. 