### PR TITLE
Fix null pointer from default avatars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,14 +52,14 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <!--- JDA -->
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.22</version>
+            <version>5.0.0</version>
         </dependency>
         <!--- Jsoup -->
         <dependency>

--- a/src/main/java/me/ryzeon/transcripts/DiscordHtmlTranscripts.java
+++ b/src/main/java/me/ryzeon/transcripts/DiscordHtmlTranscripts.java
@@ -390,7 +390,7 @@ public class DiscordHtmlTranscripts {
                 authorName.attr("title", Objects.requireNonNull(author.getGlobalName()));
                 authorName.text(author.getName());
                 authorName.attr("data-user-id", author.getId());
-                authorAvatar.attr("src", Objects.requireNonNull(author.getAvatarUrl()));
+                authorAvatar.attr("src", Objects.requireNonNull(author.getEffectiveAvatarUrl()));
             } else {
                 // Handle the case when author is null (e.g., when the message is from a bot)
                 authorName.attr("title", "Bot");


### PR DESCRIPTION
This fixes an error that occurs when a user has a default avatar as `getAvatarUrl` will return null when no custom avater is set. Therefore, using `getEffectiveAvatarUrl` is the desired method.

I additionally updated Lombok and JDA as I was getting errors when compiling (from Lombok)